### PR TITLE
umber.h: Don't set string size in `umber_class_new` params

### DIFF
--- a/src/umber.c
+++ b/src/umber.c
@@ -39,9 +39,9 @@ struct umber_class_t {
 };
 
 umber_class_t const* umber_class_new(
-	char const name[UMBER_CLASS_NAME_MAX],
+	char const* name,
 	umber_lvl_t const default_lvl,
-	char const description[UMBER_CLASS_DESCRIPTION_MAX]
+	char const* description
 ) {
 	// Validate name.
 

--- a/src/umber.h
+++ b/src/umber.h
@@ -83,15 +83,15 @@ typedef struct umber_class_t umber_class_t;
  * As long as you don't introduce a memory leak, you don't have to free this memory.
  * If you want/need to anyway, you can just use {@link free} on the returned pointer.
  *
- * @param name The class' fully-qualified name.
+ * @param name The class' fully-qualified name. Must be {@link UMBER_CLASS_NAME_MAX} characters or less, NULL-terminator included.
  * @param default_lvl The class' default log level.
- * @param description The class' description.
+ * @param description The class' description. Must be {@link UMBER_CLASS_DESCRIPTION_MAX} characters or less, NULL-terminator included.
  * @return A pointer to the new logging class or NULL if the class could not be created.
  */
 umber_class_t const* umber_class_new(
-	char const name[UMBER_CLASS_NAME_MAX],
+	char const* name,
 	umber_lvl_t const default_lvl,
-	char const description[UMBER_CLASS_DESCRIPTION_MAX]
+	char const* description
 );
 
 /**


### PR DESCRIPTION
I initially thought these parameter annotations would indicate a maximum size array that could be passed to them. Unfortunately they actually indicate an exact size to be passed. When compiling with certain compilers:

```
gv.c:28:15: error: ‘umber_class_new’ reading 32 bytes from a region of size 12 [-Werror=stringop-overread] 28 | cls = umber_class_new("aqua.kos.gv", UMBER_LVL_INFO, "KOS GrapeVine interaction."); | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ gv.c:28:15: note: referencing argument 1 of type ‘const char[32]’
```

The solution is just to turn these into boring old pointers and to just document the max sizes in the doc comment.